### PR TITLE
Make notifier have correct action, make use attachment card

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -36,15 +36,30 @@ elif [ -n "$DEPLOY" ]; then
     export ACTION_URL=$WERCKER_DEPLOY_URL
 fi
 
-export MESSAGE="$ACTION for $WERCKER_APPLICATION_NAME by $WERCKER_STARTED_BY has $WERCKER_RESULT on branch $WERCKER_GIT_BRANCH"
+export MESSAGE="<$ACTION_URL|$ACTION> for $WERCKER_APPLICATION_NAME by $WERCKER_STARTED_BY has $WERCKER_RESULT on branch $WERCKER_GIT_BRANCH"
+export FALLBACK="$ACTION for $WERCKER_APPLICATION_NAME by $WERCKER_STARTED_BY has $WERCKER_RESULT on branch $WERCKER_GIT_BRANCH"
+export COLOR="good"
+
+if [ "$WERCKER_RESULT" = "failed" ]; then
+  export MESSAGE="$MESSAGE at step: $WERCKER_FAILED_STEP_DISPLAY_NAME"
+  export FALLBACK="$FALLBACK at step: $WERCKER_FAILED_STEP_DISPLAY_NAME"
+  export COLOR="danger"
+fi
 
 # construct the json
 json="{
     \"channel\": \"#$WERCKER_SLACK_NOTIFIER_CHANNEL\",
     \"username\": \"$WERCKER_SLACK_NOTIFIER_USERNAME\",
-    \"text\":\"$MESSAGE\",
-    \"icon_url\":\"$WERCKER_SLACK_NOTIFIER_ICON_URL\"
+    \"icon_url\":\"$WERCKER_SLACK_NOTIFIER_ICON_URL\",
+    \"attachments\":[
+      {
+        \"fallback\": \"$FALLBACK\",
+        \"text\": \"$MESSAGE\",
+        \"color\": \"$COLOR\"
+      }
+    ]
 }"
+
 
 # skip notifications if not interested in passed builds or deploys
 if [ "$WERCKER_SLACK_NOTIFIER_NOTIFY_ON" = "failed" ]; then

--- a/run.sh
+++ b/run.sh
@@ -26,14 +26,14 @@ if [ ! -n "$WERCKER_SLACK_NOTIFIER_ICON_URL" ]; then
 fi
 
 # check if this event is a build or deploy
-if [ -n "$BUILD" ]; then
-    # its a build!
-    export ACTION="build"
-    export ACTION_URL=$WERCKER_BUILD_URL
-elif [ -n "$DEPLOY" ]; then
+if [ -n "$DEPLOY" ]; then
     # its a deploy!
     export ACTION="deploy"
     export ACTION_URL=$WERCKER_DEPLOY_URL
+else
+    # its a build!
+    export ACTION="build"
+    export ACTION_URL=$WERCKER_BUILD_URL
 fi
 
 export MESSAGE="<$ACTION_URL|$ACTION> for $WERCKER_APPLICATION_NAME by $WERCKER_STARTED_BY has $WERCKER_RESULT on branch $WERCKER_GIT_BRANCH"

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: slack-notifier
-version: 0.1.4
+version: 0.1.5
 description: Posts wercker build/deploy status to a Slack channel.
 keywords:
   - notification


### PR DESCRIPTION
The `$BUILD` variable wasn't in our environment variables for builds, so I copied the hipchat-notifier of checking for deploy and defaulting to build.
Also changed the message to be prettier, and use slack attachments instead: https://api.slack.com/docs/attachments

It now looks like this:
![screen shot 2015-02-28 at 12 12 23 pm](https://cloud.githubusercontent.com/assets/204566/6427903/8ada4f4e-bf43-11e4-96f6-b02a80e6de6e.png)
