### PR TITLE
Multiple fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 wercker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # step-slack
 
-A slack notifier written in `bash`.
+A slack notifier written in `bash` and `curl`. Make sure you create a Slack
+webhook first (see the Slack integrations page to set one up).
 
 [![wercker status](https://app.wercker.com/status/94f767fe85199d1f7f2dd064f36802bb/s "wercker status")](https://app.wercker.com/project/bykey/94f767fe85199d1f7f2dd064f36802bb)
 
-## Usage
+# Options
 
-In your `wercker.yml` file add an afterstep in your build or deploy
-section (or both) with the following contents:
+- `url` The Slack webhook url
+- `channel` The Slack channel
+- `username` Username of the notification message
+- `icon_url` (optional) A url that specifies an image to use as the avatar icon in Slack
+- `notify_on` (optional) If set to `failed`, it will only notify on failed
+builds or deploys.
+
+# Example
 
 ```yaml
+build:
     after-steps:
         - slack-notifier:
             url: $SLACK_URL
@@ -17,14 +25,12 @@ section (or both) with the following contents:
             username: myamazingbotname
 ```
 
-Where `$SLACK_URL` is a Slack webhook url (see the Slack integrations page to
-set one up)
+# License
 
-## Other optional fields
+The MIT License (MIT)
 
-```yaml
-icon_url: # a url that specifies an image to use as the avatar icon in Slack
-notify_on: "failed" # just notify on failed builds or deploys
-```
+# Changelog
 
+## 1.0.0
 
+- Initial release

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: slack-notifier
-version: 1.0.0
+version: 1.0.1
 description: Posts wercker build/deploy status to a Slack channel.
 keywords:
   - notification
@@ -16,8 +16,8 @@ properties:
     type: string
     required: false
   notify_on:
-      type: string
-      required: false
+    type: string
+    required: false
   icon_url:
     type: string
     required: false

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,9 @@
+box: wercker/default
+build:
+    steps:
+        - shellcheck:
+            files: run.sh
+
+        - script:
+            name: prepare output
+            code: rm -rf $WERCKER_ROOT/.git


### PR DESCRIPTION
- Fix checking for required parameters (`WERCKER_SLACK_NOTIFIER_URL`, `WERCKER_SLACK_NOTIFIER_CHANNEL`).
- Use `fail` if one of the required parameters are not supplied, instead of using `error`.
- Remove a leading `#` character from channel, instead of showing a error.
- Fix various shellcheck related issues
- Add LICENSE
- Update README to standard wercker layout
- Remove .git directory from step package
- Bump version