### PR TITLE
Make channel optional

### DIFF
--- a/build-esen.sh
+++ b/build-esen.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+WARN_COLOR=$(tput setaf 3 ; tput bold)
+SUCCESS_COLOR=$(tput setaf 2 ; tput bold)
+ERROR_COLOR=$(tput setaf 1 ; tput bold)
+INFO_COLOR=$(tput setaf 7 ; tput bold )
+DEBUG_COLOR=$(tput setaf 8 ; tput bold)
+RESET_COLOR=$(tput sgr0)
+
+function _message() {
+    msg=$1
+    color=$2
+    echo -e "${color}${msg}${RESET_COLOR}"
+}
+
+function success() {
+    _message "${1}" $SUCCESS_COLOR
+}
+
+function info() {
+    _message "${1}" $INFO_COLOR
+}
+
+function debug() {
+    _message "${1}" $DEBUG_COLOR
+}
+
+function warn() {
+    _message "${1}" $WARN_COLOR
+}
+
+function error() {
+    _message "error: ${1}" $ERROR_COLOR
+}
+
+function fail() {
+    _message "failed: ${1}" $ERROR_COLOR
+    echo "${1}" > "$WERCKER_REPORT_MESSAGE_FILE"
+    exit 1
+}
+
+
+function setMessage() {
+  echo "${1}" > "$WERCKER_REPORT_MESSAGE_FILE"
+}
+
+
+
+# Make sure we fail on all errors
+set -e

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
+#source build-esen.sh
 
 # check if slack webhook url is present
 if [ -z "$WERCKER_SLACK_NOTIFIER_URL" ]; then
   fail "Please provide a Slack webhook URL"
-fi
-
-# get the channel name to post notifications to
-if [ -z "$WERCKER_SLACK_NOTIFIER_CHANNEL" ]; then
-  fail "Please provide a Slack channel to push notifications to"
 fi
 
 # check if a '#' was supplied in the channel name
@@ -47,8 +43,14 @@ if [ "$WERCKER_RESULT" = "failed" ]; then
 fi
 
 # construct the json
-json="{
-    \"channel\": \"#$WERCKER_SLACK_NOTIFIER_CHANNEL\",
+json="{"
+
+# channels are optional, dont send one if it wasnt specified
+if [ -n "$WERCKER_SLACK_NOTIFIER_CHANNEL" ]; then 
+    json=$json"\"channel\": \"#$WERCKER_SLACK_NOTIFIER_CHANNEL\","
+fi
+
+json=$json"
     \"username\": \"$WERCKER_SLACK_NOTIFIER_USERNAME\",
     \"icon_url\":\"$WERCKER_SLACK_NOTIFIER_ICON_URL\",
     \"attachments\":[
@@ -59,7 +61,6 @@ json="{
       }
     ]
 }"
-
 
 # skip notifications if not interested in passed builds or deploys
 if [ "$WERCKER_SLACK_NOTIFIER_NOTIFY_ON" = "failed" ]; then


### PR DESCRIPTION
Webhooks [have a default channel](https://api.slack.com/incoming-webhooks) - there is no need to force one to be set.

Also included a utility to facilitate testing, I can remove it if its an issue