### PR TITLE
Add `branch` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ webhook first (see the Slack integrations page to set one up).
 - `icon_url` (optional) A url that specifies an image to use as the avatar icon in Slack
 - `notify_on` (optional) If set to `failed`, it will only notify on failed
 builds or deploys.
+- `branch` (optional) If set, it will only notify on the given branch
+
 
 # Example
 
@@ -23,6 +25,7 @@ build:
             url: $SLACK_URL
             channel: notifications
             username: myamazingbotname
+            branch: master
 ```
 
 The `url` parameter is the [slack webhook](https://api.slack.com/incoming-webhooks) that wercker should post to.
@@ -35,6 +38,10 @@ This url is then exposed as an environment variable (in this case
 The MIT License (MIT)
 
 # Changelog
+
+## 1.2.0
+
+- added `branch` option
 
 ## 1.1.0
 

--- a/run.sh
+++ b/run.sh
@@ -69,6 +69,13 @@ if [ "$WERCKER_SLACK_NOTIFIER_NOTIFY_ON" = "failed" ]; then
 	fi
 fi
 
+# skip notifications if not on the right branch
+if [ -n "$WERCKER_SLACK_NOTIFIER_BRANCH" ]; then
+    if [ "$WERCKER_SLACK_NOTIFIER_BRANCH" -ne "$WERCKER_GIT_BRANCH" ]; then
+        return 0
+    fi
+fi
+
 # post the result to the slack webhook
 RESULT=$(curl -d "payload=$json" -s "$WERCKER_SLACK_NOTIFIER_URL" --output "$WERCKER_STEP_TEMP"/result.txt -w "%{http_code}")
 cat "$WERCKER_STEP_TEMP/result.txt"

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -21,3 +21,6 @@ properties:
   icon_url:
     type: string
     required: false
+  branch:
+    type: string
+    required: false


### PR DESCRIPTION
Allow the specification of a branch. If a branch is specifies, wercker will only notify slack on that specific branch.