### PR TITLE
Added the ability to use the icon_emoji for slack messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ webhook first (see the Slack integrations page to set one up).
 - `username` Username of the notification message
 - `channel` (optional) The Slack channel (excluding `#`)
 - `icon_url` (optional) A url that specifies an image to use as the avatar icon in Slack
+- `icon_emoji` (optional) An emoji that specifies the image to use as the avatar icon in Slack
 - `notify_on` (optional) If set to `failed`, it will only notify on failed
 builds or deploys.
 - `branch` (optional) If set, it will only notify on the given branch

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ if [ -z "$WERCKER_SLACK_NOTIFIER_USERNAME" ]; then
 fi
 
 # if no icon-url is provided for the bot use the default wercker icon
-if [ -z "$WERCKER_SLACK_NOTIFIER_ICON_URL" ]; then
+if [ -z "$WERCKER_SLACK_NOTIFIER_ICON_URL" ] && [ -z "$WERCKER_SLACK_NOTIFIER_ICON_EMOJI" ]; then
   export WERCKER_SLACK_NOTIFIER_ICON_URL="https://secure.gravatar.com/avatar/a08fc43441db4c2df2cef96e0cc8c045?s=140"
 fi
 
@@ -50,9 +50,17 @@ if [ -n "$WERCKER_SLACK_NOTIFIER_CHANNEL" ]; then
     json=$json"\"channel\": \"#$WERCKER_SLACK_NOTIFIER_CHANNEL\","
 fi
 
+if [ -z "$WERCKER_SLACK_NOTIFIER_ICON_EMOJI" ]; then
+  export ICON_TYPE=icon_url
+  export ICON_VALUE=$WERCKER_SLACK_NOTIFIER_ICON_URL
+else
+  export ICON_TYPE=icon_emoji
+  export ICON_VALUE=$WERCKER_SLACK_NOTIFIER_ICON_EMOJI
+fi
+
 json=$json"
     \"username\": \"$WERCKER_SLACK_NOTIFIER_USERNAME\",
-    \"icon_url\":\"$WERCKER_SLACK_NOTIFIER_ICON_URL\",
+    \"$ICON_TYPE\":\"$ICON_VALUE\",
     \"attachments\":[
       {
         \"fallback\": \"$FALLBACK\",

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -24,3 +24,6 @@ properties:
   branch:
     type: string
     required: false
+  icon_emoji:
+    type: string
+    required: false


### PR DESCRIPTION
Added the ability in the step to provide either the icon_emoji or the icon_url as the icon for the user. 

Defined in [slack docs](https://api.slack.com/incoming-webhooks#customizations_for_custom_integrations)